### PR TITLE
Fix for selects

### DIFF
--- a/jquery.custom.forms-0.5.js
+++ b/jquery.custom.forms-0.5.js
@@ -46,7 +46,8 @@
 			});
 			
 			$(document).bind('changeSelectValue', function(ev, element, fakeSelect) {
-				var optionName = $(element).children('option[value="'+element.get(0).value+'"]').html();
+				//var optionName = $(element).children('option[value="'+element.get(0).value+'"]').html();
+				var optionName = $(element).find('option:selected').html();
 				fakeSelect.html(optionName);
 			});
 		},
@@ -185,7 +186,8 @@
 		},
 		
 		createFakeElement: function(element, type) {
-			var value = (type == 'select') ? $(element).children('option[value="'+element.get(0).value+'"]').html() : '';
+			//var value = (type == 'select') ? $(element).children('option[value="'+element.get(0).value+'"]').html() : '';
+			var value = (type == 'select') ? $(element).find('option:selected').html() : '';
 			var disabled = element.attr('disabled') !== undefined
 			
 			var fakeElement = $('<span class="'+ this.setClass(type) +'">'+ value +'</span>');


### PR DESCRIPTION
I change $(element).children('option[value="'+element.get(0).value+'"]').html() 
with $(element).find('option:selected').html() 
so it work with selects with optiongroups.
