### PR TITLE
Add a missing CONTRIBUTING file in repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+Welcome! Thanks for your interest in contributing to this jQuery plugin. You're **almost** in the right place. More information on how to contribute to this and all other jQuery Foundation projects is over at [contribute.jquery.org](http://contribute.jquery.org). You'll definitely want to take a look at the articles on contributing [code](http://contribute.jquery.org/code).
+
+You may also want to take a look at our [commit & pull request guide](http://contribute.jquery.org/commits-and-pull-requests/) and [style guides](http://contribute.jquery.org/style-guide/) for instructions on how to maintain your fork and submit your code. Before we can merge any pull request, we'll also need you to sign our [contributor license agreement](http://contribute.jquery.org/cla).
+
+You can find us on [IRC](http://irc.jquery.org), specifically in #jquery-dev should you have any questions. If you've never contributed to open source before, we've put together [a short guide with tips, tricks, and ideas on getting started](http://contribute.jquery.org/open-source/).


### PR DESCRIPTION
Hello My Friend,

I've created a repository inspired in [github/gitignore](https://github.com/github/gitignore) that you can [check here](https://github.com/moacirosa/contributing). The idea is make easier to set the a _Code of Conduct_ for upcoming contributors. Github [has written about this in the past](https://github.com/blog/1184-contributing-guidelines) so it seems a good idea. Indeed this is an invitation in a shape of a PR. If you consider it useful and have time for _Open Source_ join me :smile: 
